### PR TITLE
Break the dependency cycles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,49 +51,112 @@ test.exe: xml-light.cma
 test_opt.exe: xml-light.cmxa
 	$(OCAMLOPT) xml-light.cmxa test.ml -o test_opt.exe
 
-xml-light.cma: xml_parser.cmo xml_lexer.cmo dtd.cmo xmlParser.cmo xml.cmo 
-	$(OCAMLC) -o xml-light.cma $(LFLAGS) $(LIBS) xml_parser.cmo xml_lexer.cmo dtd.cmo xmlParser.cmo xml.cmo
+xml-light.cma: xml_light_errors.cmo xml_light_dtd_check.cmo \
+  xml_parser.cmo xml_lexer.cmo dtd.cmo xmlParser.cmo xml.cmo
+	$(OCAMLC) -o xml-light.cma $(LFLAGS) $(LIBS) $^
 
-xml-light.cmxa: xml_parser.cmx xml_lexer.cmx dtd.cmx xmlParser.cmx xml.cmx 
-	$(OCAMLOPT) -o xml-light.cmxa $(LFLAGS) $(LIBS) xml_parser.cmx xml_lexer.cmx dtd.cmx xmlParser.cmx xml.cmx
+xml-light.cmxa: xml_light_errors.cmx xml_light_dtd_check.cmx \
+  xml_parser.cmx xml_lexer.cmx dtd.cmx xmlParser.cmx xml.cmx
+	$(OCAMLOPT) -o xml-light.cmxa $(LFLAGS) $(LIBS) $^
 
 xml-light.cmxs: xml-light.cmxa
 	$(OCAMLOPT) -shared -linkall -I . -o xml-light.cmxs xml-light.cmxa
 
-dtd.cmo: xml.cmi xml_lexer.cmi dtd.cmi
-
-dtd.cmx: xml.cmi xml_lexer.cmi dtd.cmi
-
-xml.cmo: dtd.cmi xmlParser.cmi xml_lexer.cmi xml.cmi
-
-xml.cmx: dtd.cmi xmlParser.cmi xml_lexer.cmi xml.cmi
-
-xmlParser.cmo: dtd.cmi xml.cmi xml_lexer.cmi xmlParser.cmi
-
-xmlParser.cmx: dtd.cmi xml.cmi xml_lexer.cmi xmlParser.cmi
-
-dtd.cmi: xml.cmi
-
-xml.cmi: 
-
-xmlParser.cmi: dtd.cmi xml.cmi
-
-xml_lexer.cmi: dtd.cmi
-
-xml_parser.cmo: xml_parser.ml dtd.cmi xml_parser.mli xml_parser.cmi
-
-xml_parser.cmx: xml_parser.ml dtd.cmi xml_parser.mli xml_parser.cmi
-
-xml_parser.cmi: xml_parser.mli dtd.cmi xml.cmi
-
-xml_lexer.cmo: xml_lexer.ml xml_lexer.cmi
-
-xml_lexer.cmx: xml_lexer.ml xml_lexer.cmi
+## The following is the output of 'make xml_lexer.ml xml_parser.ml; ocamldep *.ml *.mli'
+# BEGIN OCAMLDEP OUTPUT
+dtd.cmo : \
+    xml_light_types.cmi \
+    xml_light_errors.cmo \
+    xml_light_dtd_check.cmi \
+    xml_lexer.cmi \
+    dtd.cmi
+dtd.cmx : \
+    xml_light_types.cmi \
+    xml_light_errors.cmx \
+    xml_light_dtd_check.cmx \
+    xml_lexer.cmx \
+    dtd.cmi
+dtd.cmi : \
+    xml_light_types.cmi \
+    xml_light_errors.cmo \
+    xml_light_dtd_check.cmi
+test.cmo : \
+    xml.cmi \
+    dtd.cmi
+test.cmx : \
+    xml.cmx \
+    dtd.cmx
+xml.cmo : \
+    xml_light_types.cmi \
+    xml_light_errors.cmo \
+    xml_lexer.cmi \
+    xmlParser.cmi \
+    dtd.cmi \
+    xml.cmi
+xml.cmx : \
+    xml_light_types.cmi \
+    xml_light_errors.cmx \
+    xml_lexer.cmx \
+    xmlParser.cmx \
+    dtd.cmx \
+    xml.cmi
+xml.cmi : \
+    xml_light_types.cmi \
+    xml_light_errors.cmo
+xmlParser.cmo : \
+    xml_light_types.cmi \
+    xml_light_errors.cmo \
+    xml_light_dtd_check.cmi \
+    xml_lexer.cmi \
+    dtd.cmi \
+    xmlParser.cmi
+xmlParser.cmx : \
+    xml_light_types.cmi \
+    xml_light_errors.cmx \
+    xml_light_dtd_check.cmx \
+    xml_lexer.cmx \
+    dtd.cmx \
+    xmlParser.cmi
+xmlParser.cmi : \
+    xml_light_types.cmi \
+    xml_light_dtd_check.cmi
+xml_lexer.cmo : \
+    xml_parser.cmi \
+    xml_light_types.cmi \
+    xml_lexer.cmi
+xml_lexer.cmx : \
+    xml_parser.cmx \
+    xml_light_types.cmi \
+    xml_lexer.cmi
+xml_lexer.cmi : \
+    xml_light_types.cmi
+xml_light_dtd_check.cmo : \
+    xml_light_types.cmi \
+    xml_light_errors.cmo \
+    xml_light_dtd_check.cmi
+xml_light_dtd_check.cmx : \
+    xml_light_types.cmi \
+    xml_light_errors.cmx \
+    xml_light_dtd_check.cmi
+xml_light_dtd_check.cmi : \
+    xml_light_types.cmi
+xml_light_errors.cmo :
+xml_light_errors.cmx :
+xml_light_types.cmi :
+xml_parser.cmo : \
+    xml_light_types.cmi \
+    xml_parser.cmi
+xml_parser.cmx : \
+    xml_light_types.cmi \
+    xml_parser.cmi
+xml_parser.cmi : \
+    xml_light_types.cmi
+# END OCAMLDEP OUTPUT
 
 clean:
-	rm -f xml-light.cma test.exe dtd.cmo dtd.cmi test.cmo test.cmi xml.cmo xml.cmi xmlParser.cmo xmlParser.cmi dtd.cmi xml.cmi xmlParser.cmi xml_lexer.cmi xml_lexer.cmo xml_lexer.ml xml_parser.mli xml_parser.cmi xml_parser.ml xml_parser.cmo
-	rm -f xml-light.lib xml-light.a xml-light.cmxa test_opt.exe dtd.cmx dtd.obj dtd.o test.cmx test.obj test.o xml.cmx xml.obj xml.o xmlParser.cmx xmlParser.obj xmlParser.o xml_lexer.cmx xml_lexer.obj xml_lexer.o xml_parser.cmx xml_parser.obj xml_parser.o
-
+	rm -f xml_lexer.ml xml_parser.mli xml_parser.ml
+	rm -f xml-light.cma test.exe *.cmo *.cmi
+	rm -f xml-light.lib xml-light.a xml-light.cmxa xml-light.cmxs test_opt.exe *.cmx *.obj *.o
 
 # SUFFIXES
 .ml.cmo:
@@ -103,11 +166,10 @@ clean:
 	$(OCAMLOPT) $(CFLAGS) -c $<
 
 .mli.cmi:
-	$(OCAMLC) $(CFLAGS) $<
+	$(OCAMLC) $(CFLAGS) -c $<
 
-.mll.ml:
+xml_lexer.ml xml_lexer.mli: xml_lexer.mll
 	ocamllex $<
 
-.mly.ml:
+xml_parser.ml xml_parser.mli: xml_parser.mly
 	ocamlyacc $<
-

--- a/dtd.mli
+++ b/dtd.mli
@@ -21,6 +21,9 @@
  * MA 02110-1301 USA
  *)
 
+open Xml_light_types
+open Xml_light_errors
+
 (** Xml Light DTD
 
 	This module provide several functions to create, check, and use DTD
@@ -47,8 +50,7 @@
 *)
 
 (** {6 The DTD Types} *)
-
-type dtd_child =
+type dtd_child = Xml_light_types.dtd_child =
 	| DTDTag of string
 	| DTDPCData
 	| DTDOptional of dtd_child
@@ -57,31 +59,31 @@ type dtd_child =
 	| DTDChoice of dtd_child list
 	| DTDChildren of dtd_child list
 
-type dtd_element_type =
+type dtd_element_type = Xml_light_types.dtd_element_type =
 	| DTDEmpty
 	| DTDAny
 	| DTDChild of dtd_child
 
-type dtd_attr_default =
+type dtd_attr_default = Xml_light_types.dtd_attr_default =
 	| DTDDefault of string
 	| DTDRequired
 	| DTDImplied
 	| DTDFixed of string
 
-type dtd_attr_type =
+type dtd_attr_type = Xml_light_types.dtd_attr_type =
 	| DTDCData
 	| DTDNMToken
 	| DTDEnum of string list
 	| DTDID
 	| DTDIDRef
 
-type dtd_item =
+type dtd_item = Xml_light_types.dtd_item =
 	| DTDAttribute of string * string * dtd_attr_type * dtd_attr_default
 	| DTDElement of string * dtd_element_type
 
 type dtd = dtd_item list
 
-type checked
+type checked = Xml_light_dtd_check.checked
 
 (** {6 The DTD Functions} *)
 
@@ -110,7 +112,7 @@ val check : dtd -> checked
  Raise {!Dtd.Check_error} [ElementNotDeclared] if the entry point
  is not found, raise {!Dtd.Prove_error} if the Xml document failed
  to be proved with the DTD. *)
-val prove : checked -> string -> Xml.xml -> Xml.xml
+val prove : checked -> string -> xml -> xml
 
 (** Print a DTD element into a string. You can easily get a DTD
  document from a DTD data structure using for example
@@ -133,14 +135,14 @@ val to_string : dtd_item -> string
 	to report errors to the user.
 *)
 
-type parse_error_msg =
+type parse_error_msg = Xml_light_errors.dtd_parse_error_msg =
 	| InvalidDTDDecl
 	| InvalidDTDElement
 	| InvalidDTDAttribute
 	| InvalidDTDTag
 	| DTDItemExpected
 
-type check_error =
+type check_error = Xml_light_errors.dtd_check_error =
 	| ElementDefinedTwice of string
 	| AttributeDefinedTwice of string * string
 	| ElementEmptyContructor of string
@@ -148,7 +150,7 @@ type check_error =
 	| ElementNotDeclared of string
 	| WrongImplicitValueForID of string * string
 
-type prove_error =
+type prove_error = Xml_light_errors.dtd_prove_error =
 	| UnexpectedPCData
 	| UnexpectedTag of string
 	| UnexpectedAttribute of string
@@ -159,7 +161,7 @@ type prove_error =
 	| DuplicateID of string
 	| MissingID of string
 
-type parse_error = parse_error_msg * Xml.error_pos
+type parse_error = parse_error_msg * error_pos
 
 exception Parse_error of parse_error
 exception Check_error of check_error
@@ -168,8 +170,3 @@ exception Prove_error of prove_error
 val parse_error : parse_error -> string
 val check_error : check_error -> string
 val prove_error : prove_error -> string
-
-(**/**)
-
-(* internal usage only... *)
-val _raises : (string -> exn) -> unit

--- a/xml-light.mllib
+++ b/xml-light.mllib
@@ -1,0 +1,7 @@
+Xml_light_errors
+Xml_parser
+Xml_lexer
+Xml_light_dtd_check
+Dtd
+XmlParser
+Xml

--- a/xml.ml
+++ b/xml.ml
@@ -23,18 +23,11 @@
 
 open Printf
 
-type xml = 
+type xml = Xml_light_types.xml =
 	| Element of (string * (string * string) list * xml list)
 	| PCData of string
 
-type error_pos = {
-	eline : int;
-	eline_start : int;
-	emin : int;
-	emax : int;
-}
-
-type error_msg =
+type error_msg = Xml_light_errors.xml_error_msg =
 	| UnterminatedComment
 	| UnterminatedString
 	| UnterminatedEntity
@@ -45,6 +38,13 @@ type error_msg =
 	| AttributeValueExpected
 	| EndOfTagExpected of string
 	| EOFExpected
+
+type error_pos = Xml_light_errors.error_pos = {
+	eline : int;
+	eline_start : int;
+	emin : int;
+	emax : int;
+}
 
 type error = error_msg * error_pos
 
@@ -66,9 +66,7 @@ let pos source =
 		emax = max;
 	}
 
-let parse (p:XmlParser.t) (source:XmlParser.source) =
-	(* local cast Xml.xml -> xml *)
-	(Obj.magic XmlParser.parse p source : xml)
+let parse = XmlParser.parse
 
 let parse_in ch = parse default_parser (XmlParser.SChannel ch)
 let parse_string str = parse default_parser (XmlParser.SString str)
@@ -258,11 +256,3 @@ let to_string_fmt x =
 	s
 
 ;;
-XmlParser._raises (fun x p -> 
-	(* local cast : Xml.error_msg -> error_msg *)
-	Error ((Obj.magic x : error_msg),pos p))
-	(fun f -> File_not_found f)
-	(fun x p -> Dtd.Parse_error (x,
-	(* local cast : Xml.error_pos -> error_pos *)
-		(Obj.magic (pos p))));
-Dtd._raises (fun f -> File_not_found f);

--- a/xml.mli
+++ b/xml.mli
@@ -37,10 +37,9 @@
 
 (** An Xml node is either
 	[Element (tag-name, attributes, children)] or [PCData text] *)
-type xml = 
+type xml = Xml_light_types.xml =
 	| Element of (string * (string * string) list * xml list)
 	| PCData of string
-
 (** {6 Xml Parsing} *)
 
 (** For easily parsing an Xml data source into an xml data structure,
@@ -77,9 +76,9 @@ val parse_string : string -> xml
 	can be raised, see the module {!Dtd} for more informations.
  *)
 
-type error_pos
+type error_pos = Xml_light_errors.error_pos
 
-type error_msg =
+type error_msg = Xml_light_errors.xml_error_msg =
 	| UnterminatedComment
 	| UnterminatedString
 	| UnterminatedEntity

--- a/xmlParser.mli
+++ b/xmlParser.mli
@@ -58,7 +58,7 @@ val prove : t -> bool -> unit
  loading strategy, and can use the {!Dtd} module functions to parse and check
  the DTD file {i (by default, the resolve function is raising}
  {!Xml.File_not_found}). *)
-val resolve : t -> (string -> Dtd.checked) -> unit
+val resolve : t -> (string -> Xml_light_dtd_check.checked) -> unit
 
 (** When a Xml document is parsed, the parser will check that the end of the
  document is reached, so for example parsing ["<A/><B/>"] will fail instead
@@ -68,15 +68,10 @@ val check_eof : t -> bool -> unit
 
 (** Once the parser is configurated, you can run the parser on a any kind
  of xml document source to parse its contents into an Xml data structure. *)
-val parse :  t -> source -> Xml.xml
+val parse :  t -> source -> Xml_light_types.xml
 
 (** When several PCData elements are separed by a \n (or \r\n), you can
  either split the PCData in two distincts PCData or merge them with \n
  as seperator into one PCData. The default behavior is to concat the
  PCData, but this can be changed for a given parser with this flag. *)
 val concat_pcdata : t -> bool -> unit
-
-(**/**)
-
-(* internal usage only... *)
-val _raises : (Xml.error_msg -> Lexing.lexbuf -> exn) -> (string -> exn) -> (Dtd.parse_error_msg -> Lexing.lexbuf -> exn) -> unit

--- a/xml_lexer.mli
+++ b/xml_lexer.mli
@@ -43,7 +43,7 @@ exception DTDError of dtd_error
 
 type dtd_decl =
 	| DTDFile of string
-	| DTDData of Dtd.dtd
+	| DTDData of Xml_light_types.dtd
 
 type token =
 	| Tag of string * (string * string) list * bool
@@ -57,6 +57,6 @@ type pos = int * int * int * int
 val init : Lexing.lexbuf -> unit 
 val close : Lexing.lexbuf -> unit
 val token : Lexing.lexbuf -> token
-val dtd : Lexing.lexbuf -> Dtd.dtd
+val dtd : Lexing.lexbuf -> Xml_light_types.dtd
 val pos : Lexing.lexbuf -> pos
 val restore : pos -> unit

--- a/xml_lexer.mll
+++ b/xml_lexer.mll
@@ -23,7 +23,7 @@
 
 open Lexing
 open Xml_parser
-open Dtd
+open Xml_light_types
 
 type error =
 	| EUnterminatedComment

--- a/xml_light_dtd_check.ml
+++ b/xml_light_dtd_check.ml
@@ -1,0 +1,114 @@
+open Xml_light_types
+open Xml_light_errors
+
+module StringMap = Map.Make(String)
+
+type 'a map = 'a StringMap.t
+
+let create_map() = ref StringMap.empty
+
+let empty_map = create_map()
+
+let find_map m k = StringMap.find k (!m)
+
+let set_map m k v = m := StringMap.add k v (!m)
+
+let unset_map m k = m := StringMap.remove k (!m)
+
+let iter_map f m = StringMap.iter f (!m)
+
+let fold_map f m = StringMap.fold f (!m)
+
+let mem_map m k = StringMap.mem k (!m)
+
+type checked = {
+	c_elements : dtd_element_type map;
+	c_attribs : (dtd_attr_type * dtd_attr_default) map map;
+}
+
+let check dtd =
+	let attribs = create_map() in
+	let hdone = create_map() in
+	let htodo = create_map() in
+	let ftodo tag from =
+		try
+			ignore(find_map hdone tag);
+		with
+			Not_found ->
+				try
+					match find_map htodo tag with
+					| None -> set_map htodo tag from
+					| Some _ -> ()
+				with
+					Not_found ->
+						set_map htodo tag from
+	in
+	let fdone tag edata =
+		try
+			ignore(find_map hdone tag);
+			raise (Dtd_check_error (ElementDefinedTwice tag));
+		with
+			Not_found ->
+				unset_map htodo tag;
+				set_map hdone tag edata
+	in
+	let fattrib tag aname adata =
+		(match adata with
+	    | DTDID,DTDImplied -> ()
+	    | DTDID,DTDRequired -> ()
+	    | DTDID,_ -> raise (Dtd_check_error (WrongImplicitValueForID (tag,aname)))
+	    | _ -> ());
+		let h = (try
+				find_map attribs tag
+			with
+				Not_found ->
+					let h = create_map() in
+					set_map attribs tag h;
+					h) in
+		try
+			ignore(find_map h aname);
+			raise (Dtd_check_error (AttributeDefinedTwice (tag,aname)));
+		with
+			Not_found ->
+				set_map h aname adata
+	in
+	let check_item = function
+		| DTDAttribute (tag,aname,atype,adef) ->
+			let utag = String.uppercase_ascii tag in
+			ftodo utag None;
+			fattrib utag (String.uppercase_ascii aname) (atype,adef)
+		| DTDElement (tag,etype) ->
+			let utag = String.uppercase_ascii tag in
+			fdone utag etype;
+			let check_type = function
+				| DTDEmpty -> ()
+				| DTDAny -> ()
+				| DTDChild x ->
+					let rec check_child = function
+						| DTDTag s -> ftodo (String.uppercase_ascii s) (Some utag)
+						| DTDPCData -> ()
+						| DTDOptional c
+						| DTDZeroOrMore c
+						| DTDOneOrMore c ->
+							check_child c
+						| DTDChoice []
+						| DTDChildren [] ->
+							raise (Dtd_check_error (ElementEmptyContructor tag))
+						| DTDChoice l
+						| DTDChildren l ->
+							List.iter check_child l
+					in
+					check_child x
+			in
+			check_type etype
+	in
+	List.iter check_item dtd;
+	iter_map (fun t from ->
+		match from with
+		| None -> raise (Dtd_check_error (ElementNotDeclared t))
+		| Some tag -> raise (Dtd_check_error (ElementReferenced (t,tag)))
+	) htodo;
+	{
+		c_elements = !hdone;
+		c_attribs = StringMap.map (!) !attribs;
+	}

--- a/xml_light_dtd_check.mli
+++ b/xml_light_dtd_check.mli
@@ -1,0 +1,10 @@
+open Xml_light_types
+
+type 'a map = 'a Map.Make(String).t
+
+type checked = private {
+	c_elements : dtd_element_type map;
+	c_attribs : (dtd_attr_type * dtd_attr_default) map map;
+}
+
+val check : dtd -> checked

--- a/xml_light_errors.ml
+++ b/xml_light_errors.ml
@@ -1,0 +1,59 @@
+type error_pos = {
+	eline : int;
+	eline_start : int;
+	emin : int;
+	emax : int;
+}
+
+type xml_error_msg =
+	| UnterminatedComment
+	| UnterminatedString
+	| UnterminatedEntity
+	| IdentExpected
+	| CloseExpected
+	| NodeExpected
+	| AttributeNameExpected
+	| AttributeValueExpected
+	| EndOfTagExpected of string
+	| EOFExpected
+
+type xml_error = xml_error_msg * error_pos
+
+(* xml errors *)
+exception Xml_error of xml_error
+exception File_not_found of string
+
+
+(* dtd errors *)
+
+type dtd_parse_error_msg =
+	| InvalidDTDDecl
+	| InvalidDTDElement
+	| InvalidDTDAttribute
+	| InvalidDTDTag
+	| DTDItemExpected
+
+type dtd_check_error =
+	| ElementDefinedTwice of string
+	| AttributeDefinedTwice of string * string
+	| ElementEmptyContructor of string
+	| ElementReferenced of string * string
+	| ElementNotDeclared of string
+	| WrongImplicitValueForID of string * string
+
+type dtd_prove_error =
+	| UnexpectedPCData
+	| UnexpectedTag of string
+	| UnexpectedAttribute of string
+	| InvalidAttributeValue of string
+	| RequiredAttribute of string
+	| ChildExpected of string
+	| EmptyExpected
+	| DuplicateID of string
+	| MissingID of string
+
+type dtd_parse_error = dtd_parse_error_msg * error_pos
+
+exception Dtd_parse_error of dtd_parse_error
+exception Dtd_check_error of dtd_check_error
+exception Dtd_prove_error of dtd_prove_error

--- a/xml_light_types.mli
+++ b/xml_light_types.mli
@@ -1,0 +1,38 @@
+(** types shared by the Xml and Dtd modules *)
+
+type xml =
+	| Element of (string * (string * string) list * xml list)
+	| PCData of string
+
+type dtd_child =
+	| DTDTag of string
+	| DTDPCData
+	| DTDOptional of dtd_child
+	| DTDZeroOrMore of dtd_child
+	| DTDOneOrMore of dtd_child
+	| DTDChoice of dtd_child list
+	| DTDChildren of dtd_child list
+
+type dtd_element_type =
+	| DTDEmpty
+	| DTDAny
+	| DTDChild of dtd_child
+
+type dtd_attr_default =
+	| DTDDefault of string
+	| DTDRequired
+	| DTDImplied
+	| DTDFixed of string
+
+type dtd_attr_type =
+	| DTDCData
+	| DTDNMToken
+	| DTDEnum of string list
+	| DTDID
+	| DTDIDRef
+
+type dtd_item =
+	| DTDAttribute of string * string * dtd_attr_type * dtd_attr_default
+	| DTDElement of string * dtd_element_type
+
+type dtd = dtd_item list

--- a/xml_parser.mly
+++ b/xml_parser.mly
@@ -20,6 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA 02110-1301 USA
  *)	
+
+open Xml_light_types
 %}
 %token NEXT OR
 %token <string>IDENT
@@ -31,7 +33,7 @@
 %right STAR QUESTION PLUS
 
 %start dtd_element
-%type <Dtd.dtd_child> dtd_element
+%type <Xml_light_types.dtd_child> dtd_element
 %%
 
 dtd_element:
@@ -46,9 +48,9 @@ dtd_full_seq:
 ;
 dtd_seq:
 	| dtd_item NEXT dtd_children
-		{ Dtd.DTDChildren ($1 :: $3) }
+		{ DTDChildren ($1 :: $3) }
 	| dtd_item OR dtd_choice
-		{ Dtd.DTDChoice ($1 :: $3) }
+		{ DTDChoice ($1 :: $3) }
 	| dtd_item
 		{ $1 }
 ;
@@ -72,13 +74,13 @@ dtd_item:
 ;
 dtd_member:
 	| IDENT dtd_op
-		{ $2 (Dtd.DTDTag $1) }
+		{ $2 (DTDTag $1) }
 	| PCDATA dtd_op
-		{ $2 Dtd.DTDPCData }
+		{ $2 DTDPCData }
 	| IDENT
-		{ Dtd.DTDTag $1 }
+		{ DTDTag $1 }
 	| PCDATA
-		{ Dtd.DTDPCData }
+		{ DTDPCData }
 ;
 dtd_op:
 	| dtd_op_item dtd_op
@@ -88,9 +90,9 @@ dtd_op:
 ;
 dtd_op_item:
 	| STAR
-		{ (fun x -> Dtd.DTDZeroOrMore x) }
+		{ (fun x -> DTDZeroOrMore x) }
 	| QUESTION
-		{ (fun x -> Dtd.DTDOptional x) }
+		{ (fun x -> DTDOptional x) }
 	| PLUS
-		{ (fun x -> Dtd.DTDOneOrMore x) }
+		{ (fun x -> DTDOneOrMore x) }
 ;


### PR DESCRIPTION
There were several rather nasty dependency cycles in Xml-light,
which were partially worked around by mutating hook functions
and using Obj.magic, but still prevented some OCaml tooling from
working properly (ocamlbuild for example chokes on incompatible mli/ml
dependency graphs).

The current commits breaks the dependency cycles by:
- adding a module xml_types.mli for all shared datatypes
- adding a module xml_errors.ml for all shared exceptions
- moving the "checking" functionality of Dtd to
  a separate module Dtd_check

Dtd_check exports its "checked" type as a private type, which
guarantees that the only way to build a value is to use its "check"
function. The maps it uses internally are not mutable anymore (which
incurs a slight conversion cost to and from the mutable representation
used in Dtd) to preserve safety when they are passed to the outer
world -- otherwise an user could mutate the maps post-check.

Care was taken to preserve interface compatibility by re-exporting the
declarations of all new modules in the outer modules -- direct users
of Xml, Dtd and XmlParser should see no difference.

This is only a preliminary commit, I would like to do the following
improvements before a merge:
- better specify the module hierarchy in comments
- do a review to make sure interface compatibility is preserved
  (in particular for exceptions)
- use the longer names Xml_light_{types,errors} to avoid module name
  conflicts
- test with OPAM projects using xml-light that it works at runtime

To test that the new organization works, I do
  ocamlbuild xml-light.cma
(I guess I can remove xml-light.mllib in the finalized version of the
patch; the point is _not_ to change the project's build system.)
