### PR TITLE
Fix lexer incorrectly supporting escaping quotes with a backslash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+- Remove lexer support for escaping double and single quotes with a
+  preceding backslash, which was non-standard in XML.
+  (#12, #14, @MisterDA)
+
 ## 2.5
 
 - Fix to allow parsing of hexadecimal entities

--- a/src/xml_lexer.mll
+++ b/src/xml_lexer.mll
@@ -354,11 +354,6 @@ and attribute_data = parse
 and dq_string = parse
 	| '"'
 		{ Buffer.contents tmp }
-	| '\\' [ '"' '\\' ]
-		{
-			Buffer.add_char tmp (lexeme_char lexbuf 1);
-			dq_string lexbuf
-		}
 	| eof
 		{ raise (Error EUnterminatedString) }
 	| _
@@ -370,11 +365,6 @@ and dq_string = parse
 and q_string = parse
 	| '\''
 		{ Buffer.contents tmp }
-	| '\\' [ '\'' '\\' ]
-		{
-			Buffer.add_char tmp (lexeme_char lexbuf 1);
-			q_string lexbuf
-		}
 	| eof
 		{ raise (Error EUnterminatedString) }
 	| _


### PR DESCRIPTION
Remove lexer support for escaping double and single quotes with a preceding backslash, which was non-standard in XML.

Currently stacked on #13. Closes #12. 